### PR TITLE
Map high level operations and stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,73 +11,60 @@ See also [`pojo-sets`](https://www.github.com/ProdigySim/pojo-sets)
 Install the package
 
 ```bash
-yarn add pojo-sets
+yarn add pojo-maps
 ```
 
 Import and start using it!
 
 ```ts
-import { PojoSet } from 'pojo-sets';
+import { PojoMap } from 'pojo-maps';
 
-const mySet = PojoSet.from(['foo', 'bar']);
+const myMap = PojoMap.fromEntries(['a', 1]. ['b', 2]);
 ```
 
 ## Usage
 
-PojoSets are meant to be a drop-in replacement everywhere you use immutable `Record<T, boolean>` structures. Their main benefit is when contrustricting these Sets, since you get to avoid manual `[].reduce()` construction.
+PojoMap are meant to be a drop-in replacement everywhere you use immutable `Partial<Record<T, U>>` structures. Their main benefit is to handle the [ambiguity in Typescript around missing & "undefined" keys](https://github.com/microsoft/TypeScript/issues/13195).
 
 ```ts
-// Traditional set construction:
-const oldSchool = ['foo', 'bar'].reduce((acc, next) => {
-  return {
-    ...acc,
-    [next]: true,
-  };
-}, {} as Record<string, boolean>);
-// typeof oldSchool: Record<string, boolean>
+// Traditional Record types:
+declare const items: Partial<Record<string, string>>;
 
-// With PojoSet helper:
-const newHotness = PojoSet.from(['foo', 'bar']);
-// typeof newHotness: PojoSet<'foo' | 'bar'>
+// Lame
+Object.values(items); // type: Array<string | undefined>
+// Extra lame!!
+items['myvalue'] = undefined;
+
+// PojoMap:
+declare const map: PojoMap<string, string>;
+
+// Cool!
+PojoMap.values(map); // type: Array<string>
+// Wow! Error!!!
+PojoMap.set(map, 'myvalue', undefined); // Argument of type 'undefined' is not assignable to parameter
 ```
 
-The traditional method requires a manual type assertion, `reduce` has issues inferring types. And, of course, if you want stricter types on your Set, you'd have to build that manually. `PojoSet.from` handles all the type assertions for you.
-
-Since you get stricter types out of the box with `PojoSet`, you get compile time checks for well-defined sets.
-
-```ts
-// ERROR! Property 'baz' does not exist on type 'PojoSet<"foo" | "bar">'.(7053)
-if(newHotness['baz']) {
-  // ...
-}
-```
-
-For a quick demo, check out this [Typescript Playground](https://www.typescriptlang.org/play/index.html?target=99&ssl=22&ssc=2&pln=20&pc=1#code/PTAEBUCcEMBMEsAu8D2A7aAbUBnApoqAMbo6KQCuRy6AXALABQJaZoKmsAykQBYodQAXlABtAOQAzAeIA0ocQCNokcQF0AdJDywqeABT7oRIvLR4AHogCUwgHygA3k1ChtiCpDROXr0BoDjU19XUXMrNVpQcgo8WV8AXwBuJgT5RwTQaBxQACU8EkhYAB4ySHg0AHN5RQFMPGg0O2sUxhBogE8ABzwUSXZOHn4OKPzCkrKK6tBajgampiZ2gHUkXlAABRQAKxQuAlBePEweyAZmUkJzAHcACRREcxwckUlIFABbfQlpFDkFZSqNQtJZgRDdXr9G73R54Z5RLa7faIYpSGSgAA+AJU4jsizaYA2eEg0kgH2iR1w0A+eGIRyIAGscugZg9eABCJjwfr6DjcPh1H4yNSgABkotA0IeTxwQr+wJ8jFcLBwcw0mBQlX04hQDPEIMYCXxKzWWVw5Hg1EwHU6PVguAI8nAEJwRHKXUIREadIKDKyns+XXg9Wi8BpoGuR0QR0gZq671O4NAlngZBwnMY3NAvMGAo4EmUAC91GKJVLYc8C9BiwrnEriKQ1RqteI0A92Az2frWkbGPjwT1Njs9gRiuBk1Y8GhYDkNgnieCANJ4DoOER11zaODoa1ieCwCygCoQNQAfiiMTwPdakgoaGoqG8b0+Y4niCnM8288gS5Xdn0ABuWCxDgUTgKIwIIsOyJjg4G5uAQnjeEBmAgVoOh6IYQRmJYNj2IqfhZCYYS4SKIiXq0hHuEhRFEJRoBpE4mTZHkBQoEUY7yJezQ9kwt73jQ3i8Nkr64R+s7fr+q76PgiBQUio7gHY8gobEYHWFEsz1N68HUV4oDsuysmiKpeBqD2QA)
+The traditional record types require a manual type assertion. By using immutable helper methods, PojoMap can do all of the normal record operations in a typesafe manner.
 
 ### Advanced Usage
 
-For the sake of completeness, this package also contains various immutable Set operations, as well as some nice ways to construct sets from Typescript `enum`s.
-
-Check out our unit tests for complete usage. But, here's a brief overview:
+PojoMap contains helper methods to do most common `Object` or `Record` operations.
 
 ```ts
-enum Fruits {
-  Apple = 'apple',
-  Orange = 'orange',
-  Banana = 'banana',
-}
-const fruits = PojoSet.fromEnum(Fruits);
+const alphaNum = PojoMap.fromEntries([['a', 1], ['b', 2], ['c', 3]] as const);
 
-const fruitsAndVeggies = PojoSet.add(fruits, 'tomato');
+const abcd = PojoMap.set(alphaNum, 'd', 4);
+const abd = PojoMap.remove(abcd, 'c');
 
-const veggies = PojoSet.difference(fruitsAndVeggies, fruits);
+PojoMap.keys(abd); // ['a', 'b', 'd']
+PojoMap.values(abcd); // [1, 2, 3, 4]
+PojoMap.entries(alphaNum); // [['a', 1], ['b', 2], ['c', 3]]
 
-expect(PojoSet.union(fruits, veggies)).toEqual(fruitsAndVeggies);
+// Add additional types to your map?
+const empty = PojoMap.empty<string, string>();
+const withNums = PojoMap.set('a', 10);
 
-expect(PojoSet.remove(fruitsAndVeggies, 'tomato')).toEqual(fruits);
 
-expect(PojoSet.intersection(fruits, veggies)).toEqual(PojoSet.empty());
-
-// Print all fruits and veggies
-console.log(PojoSet.toArray(fruitsAndVeggies).join(', '));
+// Convert a PojoMap into a PojoSet
+const set = PojoSet.from(PojoMap.keys(alphaNum));
 ```

--- a/src/PojoMap.ts
+++ b/src/PojoMap.ts
@@ -11,11 +11,9 @@ export type PojoMap<T extends PropertyKey, U extends {}> = {
  * Create a PojoMap from a set of key-value pairs.
  * @param entries Key value pairs for creating the map.
  */
-function fromEntries<T extends PropertyKey, U extends {}>(
-  entries: Readonly<Array<readonly [T, U]>>,
-): PojoMap<T, U> {
+function fromEntries<T extends PropertyKey, U extends {}>(entries: Readonly<Array<readonly [T, U]>>): PojoMap<T, U> {
   const acc: Partial<Record<T, U>> = {};
-  for(const [key, value] of entries) {
+  for (const [key, value] of entries) {
     acc[key] = value;
   }
   return acc;
@@ -28,8 +26,8 @@ function fromEntries<T extends PropertyKey, U extends {}>(
  * @param key The key to check existence of
  * @returns true if the key exists in the PojoMap, false otherwise.
  */
-function has<T extends PropertyKey, U extends {}>(map: PojoMap<T,U>, key: T): boolean {
-  return typeof map[key] !== 'undefined'
+function has<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>, key: T): boolean {
+  return typeof map[key] !== 'undefined';
 }
 
 /**
@@ -40,11 +38,11 @@ function has<T extends PropertyKey, U extends {}>(map: PojoMap<T,U>, key: T): bo
  * @param value The entry's value
  * @returns A new PojoMap contianing the original PojoMap and the new entry.
  */
-function set<T extends PropertyKey, U extends {}>(map: PojoMap<T,U>, key: T, value: U): PojoMap<T,U> {
+function set<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>, key: T, value: U): PojoMap<T, U> {
   return {
     ...map,
     [key]: value,
-   };
+  };
 }
 
 /**
@@ -54,11 +52,11 @@ function set<T extends PropertyKey, U extends {}>(map: PojoMap<T,U>, key: T, val
  * @param key The key to remove
  * @returns A new PojoMap contianing the original map minus the given key.
  */
-function remove<T extends PropertyKey, U extends {}>(map: PojoMap<T,U>, key: T): PojoMap<T,U> {
+function remove<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>, key: T): PojoMap<T, U> {
   // Extracting the the key from the PojoMap object via destructuring
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { [key]: removed, ...remaining } = map;
-  return remaining as PojoMap<T,U>;
+  return remaining as PojoMap<T, U>;
 }
 
 /**
@@ -70,10 +68,45 @@ function empty<T extends PropertyKey, U extends {}>(): PojoMap<T, U> {
   return {};
 }
 
+/**
+ * Get the keys defined in this PojoMap.
+ * @param map A PojoMap
+ * @returns an array containing all the keys where the map is defined.
+ */
+function keys<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>): T[] {
+  const keys = Object.keys(map) as T[];
+
+  // For maximum compatibility, filter on the values, in case the user has set some fields to false manually.
+  return keys.filter(k => has(map, k));
+}
+
+/**
+ * Get all the values in this PojoMap.
+ * @param map A PojoMap
+ * @returns an array containing all the values where the map is defined.
+ */
+function values<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>): U[] {
+  // Assert that each value is defined, since keys() already filters this.
+  return keys(map).map(k => map[k] as U);
+}
+
+/**
+ * Get all the entries in this PojoMap.
+ * @param map A PojoMap
+ * @returns an array containing all the key-value pairs where the map is defined.
+ */
+function entries<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>): [T, U][] {
+  // Assert that each value is defined, since keys() already filters this.
+  return keys(map).map(k => [k, map[k] as U]);
+}
+
 export const PojoMap = {
   fromEntries,
   has,
   set,
   remove,
   empty,
+  keys,
+  values,
+  entries,
 };

--- a/src/__tests__/PojoMap.test.ts
+++ b/src/__tests__/PojoMap.test.ts
@@ -15,6 +15,30 @@ describe('PojoMap', () => {
     expect(PojoMap.empty<string, number>()).toStrictEqual({});
   });
 
+  it('should make a Map from entries', () => {
+    expect(
+      PojoMap.fromEntries([
+        ['a', 1],
+        ['b', 2],
+        ['c', 3],
+      ]),
+    ).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    });
+  });
+
+
+  it('should make a Map from entries with precise types', () => {
+    const map = PojoMap.fromEntries([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ] as const)
+    leibnizTest<typeof map, PojoMap<'a' | 'b' | 'c', 1 | 2 | 3>>(identity);
+  });
+
   it('should check whether it is defined at a key', () => {
     const map = PojoMap.fromEntries<string | number | symbol, number | boolean | string>([
       ['a', 5],
@@ -36,59 +60,107 @@ describe('PojoMap', () => {
     expect(PojoMap.has(map, 'a')).toBe(true);
     expect(PojoMap.has(map, 'b')).toBe(true);
     expect(PojoMap.has(map, 'c')).toBe(true);
+  });
+
+  it('should add to a PojoMap immutably', () => {
+    const map = PojoMap.fromEntries<string, number>([
+      ['a', 0],
+      ['b', 1],
+      ['c', 2],
+    ]);
+    const largerMap = PojoMap.set(map, 'd', 3);
+    expect(largerMap).toStrictEqual({
+      a: 0,
+      b: 1,
+      c: 2,
+      d: 3,
     });
+  });
 
-    it('should add to a PojoMap immutably', () => {
-      const map = PojoMap.fromEntries<string, number>([
-        ['a', 0],
-        ['b', 1],
-        ['c', 2],
-      ]);
-      const largerMap = PojoMap.set(map, 'd', 3);
-      expect(largerMap).toStrictEqual({
-        a: 0,
-        b: 1,
-        c: 2,
-        d: 3,
-      });
+  it('should overwrite an existing value with the same key', () => {
+    const map = PojoMap.fromEntries<string, number>([
+      ['a', 0],
+      ['b', 1],
+    ]);
+    const smallerMap = PojoMap.set(map, 'b', 5);
+    expect(smallerMap).toStrictEqual({
+      a: 0,
+      b: 5,
     });
+  });
 
-    it('should overwrite an existing value with the same key', () => {
-      const map = PojoMap.fromEntries<string, number>([
-        ['a', 0],
-        ['b', 1],
-      ]);
-      const smallerMap = PojoMap.set(map, 'b', 5);
-      expect(smallerMap).toStrictEqual({
-        a: 0,
-        b: 5,
-      });
-    }); 
-
-    it('should remove from a PojoMap immutably', () => {
-      const map = PojoMap.fromEntries<string, number>([
-        ['a', 0],
-        ['b', 1],
-      ]);
-      const smallerMap = PojoMap.remove(map, 'b');
-      expect(smallerMap).toStrictEqual({
-        a: 0,
-      });
-      expect(PojoMap.has(smallerMap, 'b')).toStrictEqual(false);
+  it('should remove from a PojoMap immutably', () => {
+    const map = PojoMap.fromEntries<string, number>([
+      ['a', 0],
+      ['b', 1],
+    ]);
+    const smallerMap = PojoMap.remove(map, 'b');
+    expect(smallerMap).toStrictEqual({
+      a: 0,
     });
+    expect(PojoMap.has(smallerMap, 'b')).toStrictEqual(false);
+  });
 
-    it('should do nothing when removing a key that doesn\'t exist', () => {
-      const map = PojoMap.fromEntries<string, number>([
-        ['a', 0],
-        ['b', 1],
-      ]);
-      const newMap = PojoMap.remove(map, 'c');
-      expect(newMap).toStrictEqual({
-        a: 0,
-        b: 1,
-      });
-      expect (newMap).toStrictEqual(map);
-      expect(Object.is(newMap, map)).toBe(false);
-      expect(PojoMap.has(newMap, 'c')).toBe(false);
-    });    
+  it("should do nothing when removing a key that doesn't exist", () => {
+    const map = PojoMap.fromEntries<string, number>([
+      ['a', 0],
+      ['b', 1],
+    ]);
+    const newMap = PojoMap.remove(map, 'c');
+    expect(newMap).toStrictEqual({
+      a: 0,
+      b: 1,
+    });
+    expect(newMap).toStrictEqual(map);
+    expect(Object.is(newMap, map)).toBe(false);
+    expect(PojoMap.has(newMap, 'c')).toBe(false);
+  });
+
+  // TODO: $ExpectError?
+  // it('should not allow undefined to be set as a value', () => {
+  //   const map: PojoMap<string, string> = PojoMap.empty();
+  //   PojoMap.values(map); // type: Array<string>
+  //   //PojoMap.set(map, 'myvalue', undefined);
+  // })
+
+  
+  it('should return the keys for a PojoMap', () => {
+    expect(
+      PojoMap.keys(
+        PojoMap.fromEntries([
+          ['a', 1],
+          ['b', 2],
+          ['c', 3],
+        ]),
+      ),
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should return the values for a PojoMap', () => {
+    expect(
+      PojoMap.values(
+        PojoMap.fromEntries([
+          ['a', 1],
+          ['b', 2],
+          ['c', 3],
+        ]),
+      ),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('should return the entries for a PojoMap', () => {
+    expect(
+      PojoMap.entries(
+        PojoMap.fromEntries([
+          ['a', 1],
+          ['b', 2],
+          ['c', 3],
+        ]),
+      ),
+    ).toEqual([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ]);
+  });
 });


### PR DESCRIPTION
Implements `keys()`, `values()` and `entries()` for PojoMaps, mimicking `Object.keys()`, `Object.values()`, and `Object.entries()`.

Adds additional type checks to unit tests.

Updates ReadMe to be customized for PojoMap.