### PR TITLE
feat(get): Implement PojoMap.get

### DIFF
--- a/src/PojoMap.ts
+++ b/src/PojoMap.ts
@@ -20,6 +20,17 @@ function fromEntries<T extends PropertyKey, U extends {}>(entries: Readonly<Arra
 }
 
 /**
+ * Get the value stored at a given key in a PojoMap.
+ *
+ * @param map A PojoMap
+ * @param key The key to retrieve the value at
+ * @returns The value at the key, or undefined.
+ */
+function get<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>, key: T): U | undefined {
+  return map[key];
+}
+
+/**
  * Check if a key is in a PojoMap.
  *
  * @param map A PojoMap
@@ -112,6 +123,7 @@ function size<T extends PropertyKey, U extends {}>(map: PojoMap<T, U>): number {
 
 export const PojoMap = {
   fromEntries,
+  get,
   has,
   set,
   remove,

--- a/src/__tests__/PojoMap.test.ts
+++ b/src/__tests__/PojoMap.test.ts
@@ -61,6 +61,31 @@ describe('PojoMap', () => {
     expect(PojoMap.has(map, 'c')).toBe(true);
   });
 
+  it('should get the value at a key', () => {
+    const map = PojoMap.fromEntries([
+      ['a', 1],
+      ['b', 0],
+      ['c', -1],
+    ]);
+
+    expect(PojoMap.get(map, 'a')).toBe(1);
+    expect(PojoMap.get(map, 'b')).toBe(0);
+    expect(PojoMap.get(map, 'c')).toBe(-1);
+    // $ExpectError
+    //expect(PojoMap.get(map, 'd')).toBeUndefined();
+
+    const res = PojoMap.get(map, 'a');
+    leibnizTest<typeof res, number | undefined>(identity);
+  });
+
+  it('should return undefined when key is not found', () => {
+    const map = PojoMap.fromEntries<string, number>([['a', 1]]);
+    expect(PojoMap.get(map, 'd')).toBeUndefined();
+
+    const res = PojoMap.get(map, 'd');
+    leibnizTest<typeof res, number | undefined>(identity);
+  });
+
   it('should add to a PojoMap immutably', () => {
     const map = PojoMap.fromEntries<string, number>([
       ['a', 0],


### PR DESCRIPTION
Somehow we forgot to implement "get".

[MDN Map.get](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get)

Like the ES6 Map, we will return undefined if the map is not defined at the key.

closes #10 
