### PR TITLE
Implement PojoMap.union()

### DIFF
--- a/src/PojoMap.ts
+++ b/src/PojoMap.ts
@@ -141,6 +141,21 @@ function map<T extends PropertyKey, U extends {}, V extends {}>(
   return fromEntries(newEntries);
 }
 
+/**
+ * Create a new PojoMap by combining two existing PojoMaps.
+ * If there are duplicate keys, the value from the second map will be used.
+ *
+ * @param baseMap The base map to copy.
+ * @param additionalMap An additional map to copy entries from. This map's values will have precedence in the result.
+ * @returns A new map containing keys & values from both input maps.
+ */
+function union<T extends PropertyKey, T2 extends PropertyKey, U extends {}, U2 extends {}>(
+  baseMap: PojoMap<T, U>,
+  additionalMap: PojoMap<T2, U2>,
+): PojoMap<T | T2, U | U2> {
+  return fromEntries<T | T2, U | U2>([...entries(baseMap), ...entries(additionalMap)]);
+}
+
 export const PojoMap = {
   fromEntries,
   get,
@@ -153,4 +168,5 @@ export const PojoMap = {
   entries,
   size,
   map,
+  union,
 };

--- a/src/__tests__/PojoMap.test.ts
+++ b/src/__tests__/PojoMap.test.ts
@@ -215,4 +215,51 @@ describe('PojoMap', () => {
       b: '2b',
     });
   });
+
+  describe('.union()', () => {
+    it('should create a new map from 2 existing maps', () => {
+      const ab = PojoMap.fromEntries([
+        ['a', 1],
+        ['b', 2],
+      ]);
+      const cd = PojoMap.fromEntries([
+        ['c', 3],
+        ['d', 4],
+      ]);
+
+      expect(PojoMap.union(ab, cd)).toStrictEqual({
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+      });
+    });
+
+    it('should overwrite keys using the 2nd map', () => {
+      const ab = PojoMap.fromEntries([
+        ['a', 1],
+        ['b', 2],
+      ]);
+      const cd = PojoMap.fromEntries([
+        ['b', 3],
+        ['c', 4],
+      ]);
+
+      expect(PojoMap.union(ab, cd)).toStrictEqual({
+        a: 1,
+        b: 3,
+        c: 4,
+      });
+
+      const ab2 = PojoMap.fromEntries([
+        ['a', 'a'],
+        ['b', 'b'],
+      ]);
+
+      expect(PojoMap.union(ab, ab2)).toStrictEqual({
+        a: 'a',
+        b: 'b',
+      });
+    });
+  });
 });

--- a/type-tests/test.ts
+++ b/type-tests/test.ts
@@ -85,3 +85,22 @@ function shouldGiveGoodTagTypeTypes() {
   ];
   PojoMap.fromEntries(users.map(u => [u.id, u])); // $ExpectType PojoMap<Opaque<string, "userid">, User>
 }
+
+function shouldUnionizeMaps() {
+  const ab = PojoMap.empty<'a' | 'b', 1 | 2>();
+  const cb = PojoMap.empty<'c' | 'd', 3 | 4>();
+
+  PojoMap.union(ab, cb); // $ExpectType PojoMap<"a" | "b" | "c" | "d", 2 | 1 | 3 | 4>
+  PojoMap.union(cb, ab); // $ExpectType PojoMap<"a" | "b" | "c" | "d", 2 | 1 | 3 | 4>
+
+  const ab2 = PojoMap.empty<'a' | 'b', 3 | 4>();
+
+  PojoMap.union(ab, ab2); // $ExpectType PojoMap<"a" | "b", 2 | 1 | 3 | 4>
+  PojoMap.union(ab2, ab); // $ExpectType PojoMap<"a" | "b", 2 | 1 | 3 | 4>
+
+  const sn = PojoMap.empty<string, number>();
+  const ns = PojoMap.empty<number, string>();
+
+  PojoMap.union(sn, ns); // $ExpectType PojoMap<string | number, string | number>
+  PojoMap.union(ns, sn); // $ExpectType PojoMap<string | number, string | number>
+}

--- a/type-tests/test.ts
+++ b/type-tests/test.ts
@@ -2,6 +2,16 @@
 
 import { PojoMap } from '.';
 
+function shouldNotAllowUndefinedNullValues() {
+  // $ExpectError
+  type UndefMap = PojoMap<string, number | undefined>;
+  // $ExpectError
+  type NullMap = PojoMap<string, number | null>;
+
+  type ABCN = 'a' | 'b' | 'c' | null;
+  // $ExpectError
+  type NullMap2 = PojoMap<string, ABCN>;
+}
 function shouldGetOptionally() {
   const abc = PojoMap.empty<'a' | 'b' | 'c', number>();
   PojoMap.get(abc, 'a'); // $ExpectType number | undefined


### PR DESCRIPTION
Implements `PojoMap.union()`, which allows the user to combine two pojomaps into one.