### PR TITLE
feat: Implement Pick and Omit

### DIFF
--- a/src/__tests__/PojoMap.test.ts
+++ b/src/__tests__/PojoMap.test.ts
@@ -216,6 +216,47 @@ describe('PojoMap', () => {
     });
   });
 
+  describe('.pick()', () => {
+    it('should only return selected keys', () => {
+      const map = PojoMap.fromEntries<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]);
+
+      expect(PojoMap.pick(map, ['a'])).toStrictEqual({
+        a: 1,
+      });
+      expect(PojoMap.pick(map, ['b'])).toStrictEqual({
+        b: 2,
+      });
+      expect(PojoMap.pick(map, ['a', 'b'])).toStrictEqual({
+        a: 1,
+        b: 2,
+      });
+    });
+  });
+
+  describe('.omit()', () => {
+    it('should filter out given keys', () => {
+      const map = PojoMap.fromEntries<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]);
+
+      expect(PojoMap.omit(map, ['a'])).toStrictEqual({
+        b: 2,
+      });
+      expect(PojoMap.omit(map, ['b'])).toStrictEqual({
+        a: 1,
+      });
+      expect(PojoMap.omit(map, ['a', 'b'])).toStrictEqual({});
+      expect(PojoMap.omit(map, [])).toStrictEqual({
+        a: 1,
+        b: 2,
+      });
+    });
+  });
+
   describe('.union()', () => {
     it('should create a new map from 2 existing maps', () => {
       const ab = PojoMap.fromEntries([

--- a/src/__tests__/tagtypes.test.ts
+++ b/src/__tests__/tagtypes.test.ts
@@ -52,4 +52,26 @@ describe('PojoMap', () => {
     leibnizTest<typeof keys, UserId[]>(identity);
     expect(keys).toEqual(['1', '2']);
   });
+
+  it('should pick and omit tag types reasonably', () => {
+    const users: User[] = [
+      {
+        id: '1' as UserId,
+        name: 'alice',
+      },
+      {
+        id: '2' as UserId,
+        name: 'bob',
+      },
+    ];
+    const usersById = PojoMap.fromEntries(users.map(u => [u.id, u]));
+
+    const justOne = PojoMap.pick(usersById, ['1' as UserId]);
+    leibnizTest<typeof justOne, PojoMap<UserId, User>>(identity);
+    expect(justOne).toStrictEqual({ 1: { id: '1', name: 'alice' } });
+
+    const justTwo = PojoMap.omit(usersById, ['1' as UserId]);
+    leibnizTest<typeof justTwo, PojoMap<UserId, User>>(identity);
+    expect(justTwo).toStrictEqual({ 2: { id: '2', name: 'bob' } });
+  });
 });


### PR DESCRIPTION
Implements `PojoMap.pick(map, keys)` and `PojoMap.omit(map, keys)`.

Omit had some typing hurdles. We want a PojoMap like `PojoMap<'a' | 'b', number>` to be able to be narrowed to `PojoMap<'b', number>` if the consumer chooses to `omit(map, ['a'])`. However, we need it to NOT overlay narrow if the `keys` parameter is an open type like `string[]`.

[This SO question](https://stackoverflow.com/questions/51954558/how-can-i-remove-a-wider-type-from-a-union-type-without-removing-its-subtypes-in) is relevant, but doesn't fully solve the issue. I also had to cover tag type scenarios for this project...

Related #16 

Closes #13 