### PR TITLE
feat: Add countBy, indexBy, groupBy reducer factories

### DIFF
--- a/src/PojoMap.ts
+++ b/src/PojoMap.ts
@@ -20,6 +20,60 @@ function fromEntries<T extends PropertyKey, U extends {}>(entries: Readonly<Arra
 }
 
 /**
+ * Create a PojoMap from a list of items, indexed by a key selector
+ * When there are repeat keys, the last item with the given key will be stored.
+ * @param items List of items to index
+ * @param keySelector A function that will return the index key for an item.
+ * @returns A new PojoMap contiaining the indexed items
+ */
+function fromIndexing<T extends PropertyKey, U extends {}>(items: readonly U[], keySelector: (item: U, index: number) => T): PojoMap<T, U> {
+  const acc: Partial<Record<T, U>> = {};
+  let i = 0;
+  for (const item of items) {
+    const key = keySelector(item, i++);
+    acc[key] = item;
+  }
+  return acc;
+}
+
+/**
+ * Create a PojoMap from a list of items, grouped by a key selector
+ * @param items List of items to group
+ * @param keySelector A function that will return the index key for an item.
+ * @returns A new PojoMap contiaining the grouped items
+ */
+function fromGrouping<T extends PropertyKey, U extends {}>(items: readonly U[], keySelector: (item: U, index: number) => T): PojoMap<T, U[]> {
+  const acc: Partial<Record<T, U[]>> = {};
+  let i = 0;
+  for (const item of items) {
+    const key = keySelector(item, i++);
+    let arr = acc[key];
+    if (!arr) {
+      acc[key] = arr = [];
+    }
+    arr.push(item);
+  }
+  return acc;
+}
+
+/**
+ * Create a PojoMap from a list of items counts, grouped by a key selector
+ * @param items List of items to group
+ * @param keySelector A function that will return the index key for an item.
+ * @returns A new PojoMap contiaining the counts of items by group
+ */
+function fromCounting<T extends PropertyKey, U extends {}>(items: readonly U[], keySelector: (item: U, index: number) => T): PojoMap<T, number> {
+  const acc: Partial<Record<T, number>> = {};
+  let i = 0;
+  for (const item of items) {
+    const key = keySelector(item, i++);
+    const count = acc[key] ?? 0;
+    acc[key] = count + 1;
+  }
+  return acc;
+}
+
+/**
  * Get the value stored at a given key in a PojoMap.
  *
  * @param map A PojoMap
@@ -143,6 +197,9 @@ function map<T extends PropertyKey, U extends {}, V extends {}>(
 
 export const PojoMap = {
   fromEntries,
+  fromIndexing,
+  fromGrouping,
+  fromCounting,
   get,
   has,
   set,

--- a/src/__tests__/PojoMap.test.ts
+++ b/src/__tests__/PojoMap.test.ts
@@ -38,6 +38,83 @@ describe('PojoMap', () => {
     leibnizTest<typeof map, PojoMap<'a' | 'b' | 'c', 1 | 2 | 3>>(identity);
   });
 
+  it('should make a Map by indexing a list of items', () => {
+    const map = PojoMap.fromIndexing(
+      [
+        {
+          name: 'alice',
+          age: 24,
+        },
+        {
+          name: 'bob',
+          age: 23,
+        },
+        {
+          name: 'alice',
+          age: 25,
+        },
+      ],
+      (person) => person.name,
+    );
+    expect(map).toStrictEqual({
+      'alice': { name: 'alice', age: 25 },
+      'bob': { name: 'bob', age: 23 },
+    });
+    expect(PojoMap.fromIndexing([], () => 'unused')).toStrictEqual({});
+  });
+
+  it('should make a Map by grouping a list of items', () => {
+    const map = PojoMap.fromGrouping(
+      [
+        {
+          name: 'alice',
+          age: 24,
+        },
+        {
+          name: 'bob',
+          age: 23,
+        },
+        {
+          name: 'alice',
+          age: 25,
+        },
+      ],
+      (person) => person.name,
+    );
+    expect(map).toStrictEqual({
+      'alice': [{ name: 'alice', age: 24 }, { name: 'alice', age: 25 }],
+      'bob': [{ name: 'bob', age: 23 }],
+    });
+
+    expect(PojoMap.fromGrouping([], () => 'unused')).toStrictEqual({});
+  });
+
+  it('should make a Map by counting a list of items', () => {
+    const map = PojoMap.fromCounting(
+      [
+        {
+          name: 'alice',
+          age: 24,
+        },
+        {
+          name: 'bob',
+          age: 23,
+        },
+        {
+          name: 'alice',
+          age: 25,
+        },
+      ],
+      (person) => person.name,
+    );
+    expect(map).toStrictEqual({
+      'alice': 2,
+      'bob': 1,
+    });
+
+    expect(PojoMap.fromCounting([], () => 'unused')).toStrictEqual({});
+  });
+
   it('should check whether it is defined at a key', () => {
     const map = PojoMap.fromEntries<string | number | symbol, number | boolean | string>([
       ['a', 5],


### PR DESCRIPTION
Adds high level reducer operations for creating PojoMaps with the names `fromIndexing`, `fromCounting`, and `fromGrouping`.

Naming is picked for 2 reasons:
1. Use the `from_` prefix in order to make it clear that this creates a PojoMap from a non-PojoMap input.
2. `groupBy` and similar terms are overloaded among many different libraries, and are generally referring to the input object rather than the output object.

closes #16 